### PR TITLE
Feat: login with mail link

### DIFF
--- a/app/Http/Controllers/V2/Passport/AuthController.php
+++ b/app/Http/Controllers/V2/Passport/AuthController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\V2\Passport;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\SendEmailJob;
+use App\Models\User;
+use App\Utils\CacheKey;
+use App\Utils\Helper;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class AuthController extends Controller
+{
+    /**
+     * Send login link to email
+     *
+     * @param Request $request
+     * @return JsonResponse
+     * @api POST /api/v2/auth/magicLogin
+     */
+    public function magicLogin(Request $request)
+    {
+        $params = $request->validate([
+            'email' => 'required|email:strict',
+            'redirect' => 'nullable'
+        ]);
+
+        if (Cache::get(CacheKey::get('LAST_SEND_LOGIN_WITH_MAIL_LINK_TIMESTAMP', $params['email']))) {
+            return $this->fail([429, __('Sending frequently, please try again later')]);
+        }
+        Cache::put(CacheKey::get('LAST_SEND_LOGIN_WITH_MAIL_LINK_TIMESTAMP', $params['email']), time(), 60); // 1 minute
+
+        $user = User::where('email', $params['email'])->first();
+        if (!$user) {
+            return $this->success(__('If the email exists, a login link will be sent to the email'));
+        }
+
+        $code = Helper::guid();
+        $key = CacheKey::get('TEMP_TOKEN', $code);
+        Cache::put($key, $user->id, 7 * 24 * 3600); // 7 days
+
+        $redirect = $request->input('redirect') ? $request->input('redirect') : 'dashboard';
+        $loginUrl = '/#/login?verify=' . $code . '&redirect=' . $redirect;
+        if (admin_setting('app_url')) {
+            $loginUrl = admin_setting('app_url') . $loginUrl;
+        } else {
+            $loginUrl = url($loginUrl);
+        }
+
+        // Send email
+        SendEmailJob::dispatch([
+            'email' => $user->email,
+            'subject' => __('Login to :name', [
+                'name' => admin_setting('app_name', 'XBoard')
+            ]),
+            'template_name' => 'mailLogin',
+            'template_value' => [
+                'name' => admin_setting('app_name', 'XBoard'),
+                'link' => $loginUrl,
+                'url' => admin_setting('app_url')
+            ]
+        ]);
+
+        return $this->success(__('If the email exists, a login link will be sent to the email'));
+    }
+}

--- a/app/Http/Controllers/V2/Passport/AuthController.php
+++ b/app/Http/Controllers/V2/Passport/AuthController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\V2\Passport;
 
 use App\Http\Controllers\Controller;
 use App\Jobs\SendEmailJob;
-use App\Models\User;
+use App\Services\UserService;
 use App\Utils\CacheKey;
 use App\Utils\Helper;
 use Illuminate\Http\JsonResponse;
@@ -32,7 +32,8 @@ class AuthController extends Controller
         }
         Cache::put(CacheKey::get('LAST_SEND_LOGIN_WITH_MAIL_LINK_TIMESTAMP', $params['email']), time(), 60); // 1 minute
 
-        $user = User::where('email', $params['email'])->first();
+        $userService = new UserService();
+        $user = $userService->getUsersByEmail($params['email'])->first();
         if (!$user) {
             return $this->success(__('If the email exists, a login link will be sent to the email'));
         }

--- a/app/Http/Routes/V2/AdminRoute.php
+++ b/app/Http/Routes/V2/AdminRoute.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Routes\V2;
 
 use Illuminate\Contracts\Routing\Registrar;
@@ -12,9 +13,9 @@ class AdminRoute
             'middleware' => ['admin', 'log'],
         ], function ($router) {
             // Stat
-            $router->get ('/stat/override', 'V2\\Admin\\StatController@override');
-            $router->get ('/stat/record', 'V2\\Admin\\StatController@record');
-            $router->get ('/stat/ranking', 'V2\\Admin\\StatController@ranking');
+            $router->get('/stat/override', 'V2\\Admin\\StatController@override');
+            $router->get('/stat/record', 'V2\\Admin\\StatController@record');
+            $router->get('/stat/ranking', 'V2\\Admin\\StatController@ranking');
         });
     }
 }

--- a/app/Http/Routes/V2/PassportRoute.php
+++ b/app/Http/Routes/V2/PassportRoute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Routes\V2;
+
+use Illuminate\Contracts\Routing\Registrar;
+
+class PassportRoute
+{
+    public function map(Registrar $router)
+    {
+        $router->group([
+            'prefix' => 'passport'
+        ], function ($router) {
+            // Auth
+            $router->post('/auth/magicLogin', 'V2\\Passport\\AuthController@magicLogin');
+        });
+    }
+}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,9 +12,9 @@ services:
     ports:
       - "6379:6379"
     networks:
-        - app-network
+      - app-network
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
 
   mariadb:
@@ -42,3 +42,4 @@ services:
       - app-network
     volumes:
       - xboard-config:/www/config
+      - ./:/www


### PR DESCRIPTION
Created new API `POST /api/v2/auth/magicLogin`.

Accepting parameters:
- `email` required, user's email address.
- `redirect` optional, redirect target.

Response:
```json
{
    "status": "success",
    "message": "操作成功",
    "data": "If the email exists, a login link will be sent to the email",
    "error": null
}
```

This operation will send an email to user's mailbox with the login URL. The URL contains `verify` parameter, which should be verified by frontend. Next, the frontend requests `POST /api/v1/auth/token2Login` with the parameter `verify`, and the back-end returns auth data, refer to /app/Http/Controllers/V1/Passport/AuthController.php:288, which is a old v2board logic.

The old version of the `POST /api/v1/auth/loginWithMailLink` method in v2board requires admin to configure the setting `login_with_mail_link_enable`, which does not actually exist in admin management frontend. The new version removed this limitation, but the system must be correctly configured to send email in SMTP.